### PR TITLE
Ensure original URL is used if CLIST response fails

### DIFF
--- a/api.py
+++ b/api.py
@@ -77,7 +77,7 @@ def get_clist_info(problem):
         if (response['url'] and problem.grader not in response['url']) or (response['archive_url'] and problem.grader not in response['archive_url']):
             return None
 
-        problem.url = response['archive_url'] or response['url']
+        problem.url = response['archive_url'] or response['url'] or problem.url
         problem.rating_clist = response['rating']
 
         return problem


### PR DESCRIPTION
`get_recent_problems` usually doesn't returns a problem without a `url` field, so if we get None as its value, I'm guessing it's because `get_clist_info` overwrites it. Not sure if this actually fixes it though.