### PR TITLE
Fix solve message to include CLIST difficulty if available

### DIFF
--- a/server.py
+++ b/server.py
@@ -157,8 +157,10 @@ async def read_last_problem_loop():
 
             if problem.rating_grader and problem.rating_clist:
                 difficulty = f'dificulty: {problem.rating_grader}/clist: {problem.rating_clist}'
-            else:
-                difficulty = f'difficulty: {problem.rating_grader}' or f'clist difficulty: {problem.rating_clist}'
+            elif problem.rating_grader:
+                difficulty = f'difficulty: {problem.rating_grader}'
+            elif problem.rating_clist:
+                difficulty = f'clist difficulty: {problem.rating_clist}'
 
             if difficulty:
                 problem_text = f'{problem_text} ({difficulty})'


### PR DESCRIPTION
Currently sends "difficulty: None" even though CLIST rating is returned